### PR TITLE
[Fix]] 회원탈퇴 시 모든 친구의 내정보 삭제

### DIFF
--- a/DontForgetProject/.idea/deploymentTargetDropDown.xml
+++ b/DontForgetProject/.idea/deploymentTargetDropDown.xml
@@ -8,12 +8,10 @@
           <Key>
             <type value="VIRTUAL_DEVICE_PATH" />
             <value value="C:\Users\jcy\.android\avd\Pixel_6_Pro_API_33.avd" />
-            <type value="SERIAL_NUMBER" />
-            <value value="R3CTC05B2WV" />
           </Key>
         </deviceKey>
       </Target>
     </runningDeviceTargetSelectedWithDropDown>
-    <timeTargetWasSelectedWithDropDown value="2023-09-20T09:10:38.043655200Z" />
+    <timeTargetWasSelectedWithDropDown value="2023-09-21T01:41:28.170810200Z" />
   </component>
 </project>


### PR DESCRIPTION
내친구 리스트에 들어있는 모든 친구의 정보를 불러와서
해당 친구리스트에 들어있는 내정보 삭제후
다시 저장하는 기능 구현완료